### PR TITLE
extractor: Make extraction errors fatal

### DIFF
--- a/cmd/get-bc/main.go
+++ b/cmd/get-bc/main.go
@@ -42,11 +42,9 @@ func main() {
 	// Parse command line
 	var args = os.Args
 
-	shared.Extract(args)
+	exitCode := shared.Extract(args)
 
 	shared.LogInfo("Calling %v DID NOT TELL US WHAT HAPPENED\n", os.Args)
 
-	// could be more honest about our success here
-	os.Exit(0)
-
+	os.Exit(exitCode)
 }

--- a/shared/extractor.go
+++ b/shared/extractor.go
@@ -257,7 +257,8 @@ func resolveTool(defaultPath string, envPath string, usrPath string) (path strin
 
 func handleExecutable(ea ExtractionArgs) (success bool) {
 	// get the list of bitcode paths
-	artifactPaths, success := ea.Extractor(ea.InputFile)
+	var artifactPaths []string
+	artifactPaths, success = ea.Extractor(ea.InputFile)
 	if !success {
 		return
 	}
@@ -307,7 +308,8 @@ func handleThinArchive(ea ExtractionArgs) (success bool) {
 	for index, obj := range objectFiles {
 		LogInfo("obj = '%v'\n", obj)
 		if len(obj) > 0 {
-			artifacts, success := ea.Extractor(obj)
+			var artifacts []string
+			artifacts, success = ea.Extractor(obj)
 			if !success {
 				return
 			}
@@ -462,8 +464,8 @@ func handleArchive(ea ExtractionArgs) (success bool) {
 		for i := 1; i <= instance; i++ {
 
 			if obj != "" && extractFile(ea, inputFile, obj, i) {
-
-				artifacts, success := ea.Extractor(obj)
+				var artifacts []string
+				artifacts, success = ea.Extractor(obj)
 				if !success {
 					return
 				}

--- a/shared/extractor.go
+++ b/shared/extractor.go
@@ -67,7 +67,7 @@ type ExtractionArgs struct {
 	LlvmArchiverName    string
 	ArchiverName        string
 	ArArgs              []string
-	Extractor           func(string) []string
+	Extractor           func(string) ([]string, bool)
 }
 
 //for printing out the parsed arguments, some have been skipped.

--- a/shared/extractor.go
+++ b/shared/extractor.go
@@ -307,7 +307,10 @@ func handleThinArchive(ea ExtractionArgs) (success bool) {
 	for index, obj := range objectFiles {
 		LogInfo("obj = '%v'\n", obj)
 		if len(obj) > 0 {
-			artifacts := ea.Extractor(obj)
+			artifacts, success := ea.Extractor(obj)
+			if !success {
+				return
+			}
 			LogInfo("\t%v\n", artifacts)
 			artifactFiles = append(artifactFiles, artifacts...)
 			for _, bc := range artifacts {
@@ -460,7 +463,10 @@ func handleArchive(ea ExtractionArgs) (success bool) {
 
 			if obj != "" && extractFile(ea, inputFile, obj, i) {
 
-				artifacts := ea.Extractor(obj)
+				artifacts, success := ea.Extractor(obj)
+				if !success {
+					return
+				}
 				LogInfo("\t%v\n", artifacts)
 				artifactFiles = append(artifactFiles, artifacts...)
 				for _, bc := range artifacts {

--- a/shared/extractor.go
+++ b/shared/extractor.go
@@ -686,22 +686,20 @@ func extractSectionDarwin(inputFile string) (contents []string, success bool) {
 	machoFile, err := macho.Open(inputFile)
 	if err != nil {
 		LogError("Mach-O file %s could not be read.", inputFile)
-		success = false
 		return
 	}
 	section := machoFile.Section(DarwinSectionName)
 	if section == nil {
 		LogError("The %s section of %s is missing!\n", DarwinSectionName, inputFile)
-		success = false
 		return
 	}
 	sectionContents, errContents := section.Data()
 	if errContents != nil {
 		LogError("Error reading the %s section of Mach-O file %s.", DarwinSectionName, inputFile)
-		success = false
 		return
 	}
 	contents = strings.Split(strings.TrimSuffix(string(sectionContents), "\n"), "\n")
+	success = true
 	return
 }
 
@@ -709,22 +707,20 @@ func extractSectionUnix(inputFile string) (contents []string, success bool) {
 	elfFile, err := elf.Open(inputFile)
 	if err != nil {
 		LogError("ELF file %s could not be read.", inputFile)
-		success = false
 		return
 	}
 	section := elfFile.Section(ELFSectionName)
 	if section == nil {
 		LogError("Error reading the %s section of ELF file %s.", ELFSectionName, inputFile)
-		success = false
 		return
 	}
 	sectionContents, errContents := section.Data()
 	if errContents != nil {
 		LogError("Error reading the %s section of ELF file %s.", ELFSectionName, inputFile)
-		success = false
 		return
 	}
 	contents = strings.Split(strings.TrimSuffix(string(sectionContents), "\n"), "\n")
+	success = true
 	return
 }
 


### PR DESCRIPTION
Prior to this, running `get-bc` on a binary with no `.llvm_bc` (or corresponding Mach-O section) would print an error message but exit with 0.

This turns those errors into true failures, making it easier to diagnose when `get-bc` has been run on an incorrect or mis-generated binary.

In progress.