### PR TITLE
Don't treat -w/-W as compile-only indicators

### DIFF
--- a/shared/compiler.go
+++ b/shared/compiler.go
@@ -119,6 +119,7 @@ func buildAndAttachBitcode(compilerExecName string, pr ParserResult, bcObjLinks 
 		for i, srcFile := range pr.InputFiles {
 			objFile, bcFile := getArtifactNames(pr, i, hidden)
 			if hidden {
+				LogDebug("not compile only; building object files")
 				buildObjectFile(compilerExecName, pr, srcFile, objFile)
 				*newObjectFiles = append(*newObjectFiles, objFile)
 			}
@@ -271,6 +272,7 @@ func compileTimeLinkFiles(compilerExecName string, pr ParserResult, objFiles []s
 func buildObjectFile(compilerExecName string, pr ParserResult, srcFile string, objFile string) (success bool) {
 	args := pr.CompileArgs[:]
 	args = append(args, srcFile, "-c", "-o", objFile)
+	LogDebug("buildObjectFile: %v", args)
 	success, err := execCmd(compilerExecName, args, "")
 	if !success {
 		LogError("Failed to build object file for %s because: %v\n", srcFile, err)

--- a/shared/compiler.go
+++ b/shared/compiler.go
@@ -119,7 +119,6 @@ func buildAndAttachBitcode(compilerExecName string, pr ParserResult, bcObjLinks 
 		for i, srcFile := range pr.InputFiles {
 			objFile, bcFile := getArtifactNames(pr, i, hidden)
 			if hidden {
-				LogDebug("not compile only; building object files")
 				buildObjectFile(compilerExecName, pr, srcFile, objFile)
 				*newObjectFiles = append(*newObjectFiles, objFile)
 			}

--- a/shared/parser.go
+++ b/shared/parser.go
@@ -541,7 +541,6 @@ func (pr *ParserResult) verboseFlagCallback(_ string, _ []string) {
 }
 
 func (pr *ParserResult) compileOnlyCallback(_ string, _ []string) {
-	LogDebug("compileOnlyCallback")
 	pr.IsCompileOnly = true
 }
 

--- a/shared/parser.go
+++ b/shared/parser.go
@@ -177,8 +177,8 @@ func Parse(argList []string) ParserResult {
 		"--version": {0, pr.compileOnlyCallback},
 		"-v":        {0, pr.compileOnlyCallback},
 
-		"-w": {0, pr.compileOnlyCallback},
-		"-W": {0, pr.compileOnlyCallback},
+		// "-w": {0, pr.compileOnlyCallback},
+		// "-W": {0, pr.compileOnlyCallback},
 
 		"-emit-llvm": {0, pr.emitLLVMCallback},
 		"-flto":      {0, pr.linkTimeOptimizationCallback},

--- a/shared/parser.go
+++ b/shared/parser.go
@@ -177,8 +177,8 @@ func Parse(argList []string) ParserResult {
 		"--version": {0, pr.compileOnlyCallback},
 		"-v":        {0, pr.compileOnlyCallback},
 
-		// "-w": {0, pr.compileOnlyCallback},
-		// "-W": {0, pr.compileOnlyCallback},
+		"-w": {0, pr.compileUnaryCallback},
+		"-W": {0, pr.compileUnaryCallback},
 
 		"-emit-llvm": {0, pr.emitLLVMCallback},
 		"-flto":      {0, pr.linkTimeOptimizationCallback},

--- a/shared/parser.go
+++ b/shared/parser.go
@@ -541,6 +541,7 @@ func (pr *ParserResult) verboseFlagCallback(_ string, _ []string) {
 }
 
 func (pr *ParserResult) compileOnlyCallback(_ string, _ []string) {
+	LogDebug("compileOnlyCallback")
 	pr.IsCompileOnly = true
 }
 


### PR DESCRIPTION
Fixes #42: builds that don't generate their own intermediate objects but *do* use the `-w` or `-W` flags were treated as "compile-only" builds, causing GLLVM to incorrectly assume that the intermediate objects were already present. 

This PR fixes the issue by giving those flags the vanilla "unary" callback treatment, rather than the special "compile-only" callback treatment.