### PR TITLE
extractor, utils: dedupe bitcode paths before linking

### DIFF
--- a/shared/extractor.go
+++ b/shared/extractor.go
@@ -286,6 +286,9 @@ func handleExecutable(ea ExtractionArgs) (success bool) {
 		sort.Strings(artifactPaths)
 	}
 
+	// Deduplicate any files to link
+	dedupeStrings(&filesToLink)
+
 	// Write manifest
 	if ea.WriteManifest {
 		if !writeManifest(ea, filesToLink, artifactPaths) {

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -75,3 +75,17 @@ func runCmd(cmdExecName string, args []string) (output string, err error) {
 	output = outb.String()
 	return
 }
+
+// Deduplicate a potentially unsorted list of strings in-place without changing their order
+func dedupeStrings(strings *[]string) {
+	seen := make(map[string]bool)
+	count := 0
+	for _, s := range *strings {
+		if _, exists := seen[s]; !exists {
+			seen[s] = true
+			(*strings)[count] = s
+			count++
+		}
+	}
+	*strings = (*strings)[:count]
+}


### PR DESCRIPTION
This is my attempt at fixing #53.

Let me know what you think -- Go isn't my strongest language, so I wasn't sure how idiomatic my implementation here is.