### PR TITLE
get-bc: tweak LogInfo message

### DIFF
--- a/cmd/get-bc/main.go
+++ b/cmd/get-bc/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	exitCode := shared.Extract(args)
 
-	shared.LogInfo("Calling %v DID NOT TELL US WHAT HAPPENED\n", os.Args)
+	shared.LogInfo("Completed call: %v, exiting with %v\n", os.Args, exitCode)
 
 	os.Exit(exitCode)
 }


### PR DESCRIPTION
This is a very small tweak, so feel free to ignore: I dropped the all-caps message here since it's printed unconditionally at the `INFO` loglevel, and because it was confusing some people who've been sending me error reports (they thought it was an indicator of failure, when it's really just printed at the end of each `get-bc` invocation).