### PR TITLE
fix flang .mod file conflict issue

### DIFF
--- a/shared/compiler.go
+++ b/shared/compiler.go
@@ -81,10 +81,19 @@ func Compile(args []string, compiler string) (exitCode int) {
 		var bcObjLinks []bitcodeToObjectLink
 		var newObjectFiles []string
 
-		wg.Add(2)
-		go execCompile(compilerExecName, pr, &wg, &ok)
-		go buildAndAttachBitcode(compilerExecName, pr, &bcObjLinks, &newObjectFiles, &wg)
-		wg.Wait()
+		if compiler == "flang" {
+			wg.Add(1)
+			go execCompile(compilerExecName, pr, &wg, &ok)
+			wg.Wait();
+			wg.Add(1);
+			go buildAndAttachBitcode(compilerExecName, pr, &bcObjLinks, &newObjectFiles, &wg)
+			wg.Wait()
+		} else {
+			wg.Add(2)
+			go execCompile(compilerExecName, pr, &wg, &ok)
+			go buildAndAttachBitcode(compilerExecName, pr, &bcObjLinks, &newObjectFiles, &wg)
+			wg.Wait()
+		}
 
 		//grok the exit code
 		if !ok {


### PR DESCRIPTION
If we are using gflang to compiler fortran source code, conflicts may occur in some cases when execCompile generating .mod file but not finished and buildAndAttachBitcode trying to generate .mode file that has the same name.