### PR TITLE
Support cross-compilation via `-target ...` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,23 @@ This can be done by setting the `LTO_LINKING_FLAGS` to be something like
 `"-g -Wl,-plugin-opt=save-temps"` which will be appended to the flags at link time.
 This will at least preserve the bitcode files, even if `get-bc` will not be able to retrieve them for you.
 
+## Cross-compilation notes
+
+When cross-compiling a project (i.e. you pass the `--target=` or `-target` flag to the compiler), 
+you'll need to set the `GLLVM_OBJCOPY` variable to either 
+* `llvm-objcopy` to use LLVM's objcopy, which naturally supports all targets that clang does.
+* `YOUR-TARGET-TRIPLE-objcopy` to use GNU's objcopy, since `objcopy` only supports the native architecture.
+
+Example:
+```sh
+# test program
+echo 'int main() { return 0; }' > a.c 
+clang --target=aarch64-linux-gnu a.c # works
+gclang --target=aarch64-linux-gnu a.c # breaks
+GLLVM_OBJCOPY=llvm-objcopy gclang --target=aarch64-linux-gnu a.c # works
+GLLVM_OBJCOPY=aarch64-linux-gnu-objcopy gclang --target=aarch64-linux-gnu a.c # works if you have GNU's arm64 toolchain
+```
+
 ## Developer tools
 
 Debugging usually boils down to looking in the logs, maybe adding a print statement or two.

--- a/shared/parser.go
+++ b/shared/parser.go
@@ -174,6 +174,8 @@ func Parse(argList []string) ParserResult {
 		"--param":   {1, pr.defaultBinaryCallback},
 		"-aux-info": {1, pr.defaultBinaryCallback},
 
+		"-target": {1, pr.compileLinkBinaryCallback},
+
 		"--version": {0, pr.compileOnlyCallback},
 		"-v":        {0, pr.compileOnlyCallback},
 

--- a/shared/parser.go
+++ b/shared/parser.go
@@ -402,6 +402,8 @@ func Parse(argList []string) ParserResult {
 		{`^.+\.(o|lo|So|so|po|a|dylib|pico|nossppico)$`, flagInfo{0, pr.objectFileCallback}}, //iam: pico and nossppico are FreeBSD
 		{`^.+\.dylib(\.\d)+$`, flagInfo{0, pr.objectFileCallback}},
 		{`^.+\.(So|so)(\.\d)+$`, flagInfo{0, pr.objectFileCallback}},
+
+        {`^--target=.+$`, flagInfo{0, pr.compileLinkUnaryCallback}},
 	}
 
 	for len(argList) > 0 {


### PR DESCRIPTION
Hi, as discussed in the issue #71 , I propose the following two changes:
- Support the `-target ARCHITECTURE` in `shared/parser.go`
- Default to `llvm-objcopy` because that's what comes with the LLVM toolchain, which supports any target. This changes the pre-existing default of `objcopy` from the GNU toolchain, which only supports the native compilation target (i.e. x86 on x86 machines, arm on arm machines).

If someone still wishes to use GNU `objcopy`, they can still use it by setting the `GLLVM_OBJCOPY=objcopy` environment variable for native targets, or the prefixed version for cross-compilation toolchains, e.g. `GLLVM_OBJCOPY=aarch64-linux-gnu-objcopy` for arm64.